### PR TITLE
update browser list for custom elements

### DIFF
--- a/packages/core-web-example/src/index.js
+++ b/packages/core-web-example/src/index.js
@@ -6,9 +6,7 @@ import "@mrhenry/core-web/modules/Intl.~locale.fr-FR";
 var event = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
 console.log(event.toLocaleString('nl-BE', { timeZone: 'UTC' }));
 
-customElements.define('mr-x', class extends HTMLElement {
-
-})
+customElements.define('mr-x', class extends HTMLElement {});
 
 // ["@mrhenry/core-web", {
 // 	browsers: {

--- a/packages/core-web-generator/generate-webcomponents.js
+++ b/packages/core-web-generator/generate-webcomponents.js
@@ -282,9 +282,10 @@ async function generateCustomElements(mapping) {
 			edge: "<79",
 			edge_mob: "*",
 			firefox: "<63",
-			safari: "*",
+			safari: "<11",
 			ie: "*",
-			opera: "<64"
+			opera: "<65",
+			samsung_mob: '<8'
 		},
 		detector: true
 	});

--- a/packages/core-web-generator/generate-webcomponents.js
+++ b/packages/core-web-generator/generate-webcomponents.js
@@ -284,7 +284,9 @@ async function generateCustomElements(mapping) {
 			firefox: "<63",
 			safari: "<11",
 			ie: "*",
-			opera: "<65",
+			opera: "<64",
+			op_mob: "<46",
+			op_mini: "*",
 			samsung_mob: '<8'
 		},
 		detector: true

--- a/packages/core-web-tests/src/test_customElements.define.extends.js
+++ b/packages/core-web-tests/src/test_customElements.define.extends.js
@@ -1,0 +1,15 @@
+QUnit.skip('customElements.define with extends', function (assert) {
+	class TestElementExtender extends HTMLButtonElement {
+		foo() {
+			return 'baz';
+		}
+	}
+
+	customElements.define('test-element-extender', TestElementExtender, { extends: 'button' });
+	const fixture = document.getElementById('qunit-fixture');
+
+	fixture.innerHTML = '<button is="test-element-extender"></button>';
+
+	const el = fixture.querySelector('button');
+	assert.equal(el.foo(), 'baz');
+});

--- a/packages/core-web-tests/src/test_customElements.define.js
+++ b/packages/core-web-tests/src/test_customElements.define.js
@@ -1,38 +1,38 @@
-QUnit.test("customElements.define", function(assert) {
+QUnit.test('customElements.define', function(assert) {
 	class TestElementA extends HTMLElement {
 		foo() {
-			return "baz";
+			return 'baz';
 		}
 	}
 
-	customElements.define("test-element-a", TestElementA);
-	const fixture = document.getElementById("qunit-fixture");
+	customElements.define('test-element-a', TestElementA);
+	const fixture = document.getElementById('qunit-fixture');
 
-	fixture.innerHTML = "<test-element-a></test-element-a>";
+	fixture.innerHTML = '<test-element-a></test-element-a>';
 
-	const el = fixture.querySelector("test-element-a");
-	assert.equal(el.foo(), "baz");
+	const el = fixture.querySelector('test-element-a');
+	assert.equal(el.foo(), 'baz');
 });
 
-QUnit.test("customElements.connectedCallback", function(assert) {
+QUnit.test('customElements.connectedCallback', function(assert) {
 	class TestElementB extends HTMLElement {
 		constructor() {
 			super();
 
-			this._content = "rendered content";
+			this._content = 'rendered content';
 		}
 
 		connectedCallback() {
-			this.innerHTML = this._content || "";
+			this.innerHTML = this._content || '';
 		}
 	}
 
-	customElements.define("test-element-b", TestElementB);
-	const fixture = document.getElementById("qunit-fixture");
+	customElements.define('test-element-b', TestElementB);
+	const fixture = document.getElementById('qunit-fixture');
 	const elStart = new TestElementB();
 
 	fixture.appendChild(elStart);
 
-	const elOut = fixture.querySelector("test-element-b");
-	assert.equal(elOut.innerHTML, "rendered content");
+	const elOut = fixture.querySelector('test-element-b');
+	assert.equal(elOut.innerHTML, 'rendered content');
 });

--- a/packages/core-web-tests/webpack.config.js
+++ b/packages/core-web-tests/webpack.config.js
@@ -1,42 +1,42 @@
-const path = require("path");
-const babelPresetEnv = require("@babel/preset-env");
+const path = require('path');
+const babelPresetEnv = require('@babel/preset-env');
 
 module.exports = {
-	mode: "production",
-	context: path.resolve(__dirname, "src"),
+	mode: 'production',
+	context: path.resolve(__dirname, 'src'),
 	output: {
-		path: path.resolve(__dirname, "dist"),
-		filename: "[name].bundle.js"
+		path: path.resolve(__dirname, 'dist'),
+		filename: '[name].bundle.js'
 	},
 	entry: {
-		"non-interactive": "./non_interactive.js"
+		'non-interactive': './non_interactive.js'
 	},
-	devtool: "source-map",
+	devtool: 'source-map',
 	module: {
 		rules: [
 			{
 				test: /\.js$/,
 				include: /core-web\/modules/,
 				use: {
-					loader: "babel-loader",
+					loader: 'babel-loader',
 					options: {
 						comments: false,
 						presets: [
 							[
 								babelPresetEnv,
 								{
-									corejs: "^3.6.3",
+									corejs: '^3.6.3',
 									targets: {
 										browsers: [
-											"chrome >= 31",
-											"edge >= 12",
-											"firefox >= 26",
-											"opera >= 26",
-											"safari >= 6",
-											"ie >= 11"
+											'chrome >= 31',
+											'edge >= 12',
+											'firefox >= 26',
+											'opera >= 26',
+											'safari >= 6',
+											'ie >= 11'
 										]
 									},
-									useBuiltIns: "usage"
+									useBuiltIns: 'usage'
 								}
 							]
 						]
@@ -47,20 +47,20 @@ module.exports = {
 				test: /\.js$/,
 				exclude: /(node_modules|core-web\/modules)/,
 				use: {
-					loader: "babel-loader",
+					loader: 'babel-loader',
 					options: {
 						comments: false,
 						plugins: [
 							[
-								"@mrhenry/core-web",
+								'@mrhenry/core-web',
 								{
 									browsers: {
-										chrome: "31",
-										firefox: "26",
-										edge: "12",
-										opera: "26",
-										safari: "6",
-										ie: "11"
+										chrome: '31',
+										firefox: '26',
+										edge: '12',
+										opera: '26',
+										safari: '6',
+										ie: '11'
 									}
 								}
 							]
@@ -69,18 +69,18 @@ module.exports = {
 							[
 								babelPresetEnv,
 								{
-									corejs: "^3.6.3",
+									corejs: '^3.6.3',
 									targets: {
 										browsers: [
-											"chrome >= 31",
-											"edge >= 12",
-											"firefox >= 26",
-											"opera >= 26",
-											"safari >= 6",
-											"ie >= 11"
+											'chrome >= 31',
+											'edge >= 12',
+											'firefox >= 26',
+											'opera >= 26',
+											'safari >= 6',
+											'ie >= 11'
 										]
 									},
-									useBuiltIns: "usage"
+									useBuiltIns: 'usage'
 								}
 							]
 						]

--- a/packages/core-web/helpers/__mapping.js
+++ b/packages/core-web/helpers/__mapping.js
@@ -22935,7 +22935,9 @@ module.exports = [
       "firefox": "<63",
       "safari": "<11",
       "ie": "*",
-      "opera": "<65",
+      "opera": "<64",
+      "op_mob": "<46",
+      "op_mini": "*",
       "samsung_mob": "<8"
     },
     "detector": true

--- a/packages/core-web/helpers/__mapping.js
+++ b/packages/core-web/helpers/__mapping.js
@@ -22933,9 +22933,10 @@ module.exports = [
       "edge": "<79",
       "edge_mob": "*",
       "firefox": "<63",
-      "safari": "*",
+      "safari": "<11",
       "ie": "*",
-      "opera": "<64"
+      "opera": "<65",
+      "samsung_mob": "<8"
     },
     "detector": true
   },


### PR DESCRIPTION
Safari has support for CustomElements that extend `HTMLElement`.
Extending native elements is not supported but also not polyfillable.

Updated the browser list to stop shipping the polyfill to newer versions of safari

[relevant discussion](https://github.com/webcomponents/polyfills/issues/102)