### PR TITLE
call expression matcher

### DIFF
--- a/packages/babel-plugin-core-web/lib/ast-matcher.js
+++ b/packages/babel-plugin-core-web/lib/ast-matcher.js
@@ -45,21 +45,30 @@ function matchNode(matcher, ast, state) {
 	if (nullish(matcher) && nullish(ast)) {
 		return true;
 	}
+
 	if (arrayish(matcher)) {
 		return matchNodes(matcher, ast, state);
 	}
+
 	if (typeof matcher !== "object") {
 		return false;
 	}
+
 	if (typeof ast !== "object") {
 		return false;
 	}
+
 	if (matcher.type === "Identifier" && matcher.isVariable) {
 		state[matcher.name] = ast;
 		return true;
 	}
+
 	if (matcher.type !== ast.type) {
 		return false;
+	}
+
+	if (matcher.type === 'CallExpression') {
+		return matchNodes(matcher.arguments, ast.arguments, state);
 	}
 
 	for (const key of getMatcherKeys(matcher)) {

--- a/packages/babel-plugin-core-web/lib/index.js
+++ b/packages/babel-plugin-core-web/lib/index.js
@@ -7,7 +7,7 @@ module.exports = function() {
 			ImportDeclaration(path, state) {
 				getInjector(state).handleImport(path, state);
 			},
-			"Identifier|MemberExpression"(path, state) {
+			"Identifier|MemberExpression|CallExpression"(path, state) {
 				getInjector(state).handleGeneric(path, state);
 			},
 			Program: {


### PR DESCRIPTION
_There is no need for this at the moment._

Could be useful to detect specific call expressions that require a polyfill.

Match call with specific locale argument :

`new Intl.RelativeTimeFormat( "en", $2 )`
`new Intl.RelativeTimeFormat( "en", { style: "narrow" } )`

Match a sub-feature :

`customElements.define( $1, $2, { extends: $3 } )`
`customElements.define( 'ce-foo', class extends HTMLButtonElement {}, { extends: 'button' } )`