### PR TITLE
Bump the all-dependencies group with 3 updates (#1629)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2671,9 +2671,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.2.tgz",
-      "integrity": "sha512-c2dxwcqbClWUUSZqM6hMzM8dAUCEaPBBciBW8iyT+62OPmfb61VVZKu4vtCyAPzE/fBYY1F2bhuTsOTBRtt7WA=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.3.tgz",
+      "integrity": "sha512-89Ikx/aME3DwslhFWr4ZLhVtc7EDAuwhu5uwdwXKFIzJT1r6/9jJI2jD0ycESzVOf+0pPZq9vHe9LCE3NE7EuA=="
     },
     "node_modules/@mrhenry/babel-plugin-core-web": {
       "resolved": "packages/babel-plugin-core-web",
@@ -3863,9 +3863,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -3893,7 +3893,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -3905,7 +3904,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -5421,9 +5419,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
-      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
+      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7454,7 +7452,7 @@
         "@babel/parser": "^7.21.8",
         "@babel/traverse": "^7.18.13",
         "@babel/types": "^7.21.5",
-        "@mdn/browser-compat-data": "^5.3.1",
+        "@mdn/browser-compat-data": "^5.3.3",
         "@webcomponents/custom-elements": "^1.5.0",
         "@webcomponents/shadycss": "^1.11.0",
         "@webcomponents/shadydom": "^1.9.0",
@@ -7479,7 +7477,7 @@
         "@mrhenry/core-web": "^1.2.0",
         "babel-loader": "^9.1.3",
         "core-js": "^3.31.1",
-        "eslint": "^8.39.0",
+        "eslint": "^8.45.0",
         "webpack": "^5.82.1",
         "webpack-cli": "^5.1.1"
       }
@@ -7491,7 +7489,7 @@
       "dependencies": {
         "@babel/core": "^7.22.8",
         "@babel/preset-env": "^7.22.7",
-        "@mdn/browser-compat-data": "^5.3.1",
+        "@mdn/browser-compat-data": "^5.3.3",
         "@mrhenry/babel-plugin-core-web": "*",
         "@mrhenry/core-web": "*",
         "babel-loader": "^9.1.3",
@@ -7500,7 +7498,7 @@
         "core-js": "^3.31.1",
         "he": "^1.2.0",
         "polyfill-library": "^4.0.0",
-        "postcss": "^8.4.25",
+        "postcss": "^8.4.26",
         "postcss-discard-comments": "^6.0.0",
         "postcss-discard-empty": "^6.0.0",
         "postcss-import": "^15.0.0",

--- a/packages/core-web-generator/package.json
+++ b/packages/core-web-generator/package.json
@@ -15,7 +15,7 @@
     "@babel/parser": "^7.21.8",
     "@babel/traverse": "^7.18.13",
     "@babel/types": "^7.21.5",
-    "@mdn/browser-compat-data": "^5.3.1",
+    "@mdn/browser-compat-data": "^5.3.3",
     "@webcomponents/custom-elements": "^1.5.0",
     "@webcomponents/shadycss": "^1.11.0",
     "@webcomponents/shadydom": "^1.9.0",

--- a/packages/core-web-tests/package.json
+++ b/packages/core-web-tests/package.json
@@ -14,7 +14,7 @@
     "@mrhenry/core-web": "^1.2.0",
     "babel-loader": "^9.1.3",
     "core-js": "^3.31.1",
-    "eslint": "^8.39.0",
+    "eslint": "^8.45.0",
     "webpack": "^5.82.1",
     "webpack-cli": "^5.1.1"
   },

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@babel/core": "^7.22.8",
     "@babel/preset-env": "^7.22.7",
-    "@mdn/browser-compat-data": "^5.3.1",
+    "@mdn/browser-compat-data": "^5.3.3",
     "@mrhenry/babel-plugin-core-web": "*",
     "@mrhenry/core-web": "*",
     "babel-loader": "^9.1.3",
@@ -34,7 +34,7 @@
     "core-js": "^3.31.1",
     "he": "^1.2.0",
     "polyfill-library": "^4.0.0",
-    "postcss": "^8.4.25",
+    "postcss": "^8.4.26",
     "postcss-discard-comments": "^6.0.0",
     "postcss-discard-empty": "^6.0.0",
     "postcss-import": "^15.0.0",


### PR DESCRIPTION
Bumps the all-dependencies group with 3 updates: [eslint](https://github.com/eslint/eslint), [@mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) and [postcss](https://github.com/postcss/postcss).


Updates `eslint` from 8.44.0 to 8.45.0
- [Release notes](https://github.com/eslint/eslint/releases)
- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/eslint/eslint/compare/v8.44.0...v8.45.0)

Updates `@mdn/browser-compat-data` from 5.3.2 to 5.3.3
- [Release notes](https://github.com/mdn/browser-compat-data/releases)
- [Changelog](https://github.com/mdn/browser-compat-data/blob/main/RELEASE_NOTES.md)
- [Commits](https://github.com/mdn/browser-compat-data/compare/v5.3.2...v5.3.3)

Updates `postcss` from 8.4.25 to 8.4.26
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.25...8.4.26)

---
updated-dependencies:
- dependency-name: eslint dependency-type: direct:development update-type: version-update:semver-minor dependency-group: all-dependencies
- dependency-name: "@mdn/browser-compat-data" dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: postcss dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies ...