### PR TITLE
Bump the all-dependencies group with 4 updates (#1633)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2671,9 +2671,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.3.tgz",
-      "integrity": "sha512-89Ikx/aME3DwslhFWr4ZLhVtc7EDAuwhu5uwdwXKFIzJT1r6/9jJI2jD0ycESzVOf+0pPZq9vHe9LCE3NE7EuA=="
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.3.5.tgz",
+      "integrity": "sha512-aGZ/OZCv96fEvUNuOoHbWN9ySODB1Xf04+TFgK3QO/PaM1NI95INaf0YUBLUbbK9lMKWqUzyJk2TPLe3ybFFXg=="
     },
     "node_modules/@mrhenry/babel-plugin-core-web": {
       "resolved": "packages/babel-plugin-core-web",
@@ -2791,9 +2791,9 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
+      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -5419,9 +5419,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-      "integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+      "version": "8.4.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7064,9 +7064,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.88.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -7430,7 +7430,7 @@
         "semver": "^7.5.4"
       },
       "devDependencies": {
-        "@types/node": "^20.4.1",
+        "@types/node": "^20.4.4",
         "@types/semver": "^7.5.0",
         "typescript": "^5.0.2"
       }
@@ -7452,7 +7452,7 @@
         "@babel/parser": "^7.21.8",
         "@babel/traverse": "^7.18.13",
         "@babel/types": "^7.21.5",
-        "@mdn/browser-compat-data": "^5.3.3",
+        "@mdn/browser-compat-data": "^5.3.5",
         "@webcomponents/custom-elements": "^1.5.0",
         "@webcomponents/shadycss": "^1.11.0",
         "@webcomponents/shadydom": "^1.9.0",
@@ -7462,7 +7462,7 @@
       },
       "devDependencies": {
         "@types/babel__traverse": "^7.18.5",
-        "@types/node": "^20.4.1",
+        "@types/node": "^20.4.4",
         "@types/semver": "^7.5.0",
         "typescript": "^5.0.2"
       }
@@ -7478,7 +7478,7 @@
         "babel-loader": "^9.1.3",
         "core-js": "^3.31.1",
         "eslint": "^8.45.0",
-        "webpack": "^5.82.1",
+        "webpack": "^5.88.2",
         "webpack-cli": "^5.1.1"
       }
     },
@@ -7489,7 +7489,7 @@
       "dependencies": {
         "@babel/core": "^7.22.8",
         "@babel/preset-env": "^7.22.7",
-        "@mdn/browser-compat-data": "^5.3.3",
+        "@mdn/browser-compat-data": "^5.3.5",
         "@mrhenry/babel-plugin-core-web": "*",
         "@mrhenry/core-web": "*",
         "babel-loader": "^9.1.3",
@@ -7498,14 +7498,14 @@
         "core-js": "^3.31.1",
         "he": "^1.2.0",
         "polyfill-library": "^4.0.0",
-        "postcss": "^8.4.26",
+        "postcss": "^8.4.27",
         "postcss-discard-comments": "^6.0.0",
         "postcss-discard-empty": "^6.0.0",
         "postcss-import": "^15.0.0",
         "postcss-normalize-whitespace": "^6.0.0",
         "postcss-preset-env": "^9.0.0",
         "postcss-split-by-media": "^0.3.0",
-        "webpack": "^5.82.1",
+        "webpack": "^5.88.2",
         "webpack-cli": "^5.1.1"
       }
     },

--- a/packages/core-web-generator/package.json
+++ b/packages/core-web-generator/package.json
@@ -15,7 +15,7 @@
     "@babel/parser": "^7.21.8",
     "@babel/traverse": "^7.18.13",
     "@babel/types": "^7.21.5",
-    "@mdn/browser-compat-data": "^5.3.3",
+    "@mdn/browser-compat-data": "^5.3.5",
     "@webcomponents/custom-elements": "^1.5.0",
     "@webcomponents/shadycss": "^1.11.0",
     "@webcomponents/shadydom": "^1.9.0",
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/babel__traverse": "^7.18.5",
-    "@types/node": "^20.4.1",
+    "@types/node": "^20.4.4",
     "@types/semver": "^7.5.0",
     "typescript": "^5.0.2"
   },

--- a/packages/core-web-tests/package.json
+++ b/packages/core-web-tests/package.json
@@ -15,7 +15,7 @@
     "babel-loader": "^9.1.3",
     "core-js": "^3.31.1",
     "eslint": "^8.45.0",
-    "webpack": "^5.82.1",
+    "webpack": "^5.88.2",
     "webpack-cli": "^5.1.1"
   },
   "volta": {

--- a/packages/core-web/package.json
+++ b/packages/core-web/package.json
@@ -35,7 +35,7 @@
     "semver": "^7.5.4"
   },
   "devDependencies": {
-    "@types/node": "^20.4.1",
+    "@types/node": "^20.4.4",
     "@types/semver": "^7.5.0",
     "typescript": "^5.0.2"
   },

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@babel/core": "^7.22.8",
     "@babel/preset-env": "^7.22.7",
-    "@mdn/browser-compat-data": "^5.3.3",
+    "@mdn/browser-compat-data": "^5.3.5",
     "@mrhenry/babel-plugin-core-web": "*",
     "@mrhenry/core-web": "*",
     "babel-loader": "^9.1.3",
@@ -34,14 +34,14 @@
     "core-js": "^3.31.1",
     "he": "^1.2.0",
     "polyfill-library": "^4.0.0",
-    "postcss": "^8.4.26",
+    "postcss": "^8.4.27",
     "postcss-discard-comments": "^6.0.0",
     "postcss-discard-empty": "^6.0.0",
     "postcss-import": "^15.0.0",
     "postcss-normalize-whitespace": "^6.0.0",
     "postcss-preset-env": "^9.0.0",
     "postcss-split-by-media": "^0.3.0",
-    "webpack": "^5.82.1",
+    "webpack": "^5.88.2",
     "webpack-cli": "^5.1.1"
   },
   "volta": {


### PR DESCRIPTION
Bumps the all-dependencies group with 4 updates: [webpack](https://github.com/webpack/webpack), [@mdn/browser-compat-data](https://github.com/mdn/browser-compat-data), [postcss](https://github.com/postcss/postcss) and [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node).


Updates `webpack` from 5.88.1 to 5.88.2
- [Release notes](https://github.com/webpack/webpack/releases)
- [Commits](https://github.com/webpack/webpack/compare/v5.88.1...v5.88.2)

Updates `@mdn/browser-compat-data` from 5.3.3 to 5.3.5
- [Release notes](https://github.com/mdn/browser-compat-data/releases)
- [Changelog](https://github.com/mdn/browser-compat-data/blob/main/RELEASE_NOTES.md)
- [Commits](https://github.com/mdn/browser-compat-data/compare/v5.3.3...v5.3.5)

Updates `postcss` from 8.4.26 to 8.4.27
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.26...8.4.27)

Updates `@types/node` from 20.4.2 to 20.4.4
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node)

---
updated-dependencies:
- dependency-name: webpack dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: "@mdn/browser-compat-data" dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: postcss dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all-dependencies
- dependency-name: "@types/node" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: all-dependencies ...